### PR TITLE
fix: deprecated Interpolation-only expressions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,42 +1,42 @@
 resource "aws_ec2_transit_gateway" "tgw" {
-  count = "${var.create_tgw ? 1 : 0}"
+  count = var.create_tgw ? 1 : 0
 
   description                     = "Transit Gateway for ${var.name}"
-  default_route_table_association = "${var.enable_default_route_table_association ? enable : disable}"
-  default_route_table_propagation = "${var.enable_default_route_table_propagation ? enable : disable}"
-  auto_accept_shared_attachments  = "${var.auto_accept_attachments ? enable : disable}"
-  dns_support                     = "${var.enable_dns_support}"
-  amazon_side_asn                 = "${var.amazon_side_asn}"
+  default_route_table_association = var.enable_default_route_table_association ? enable : disable
+  default_route_table_propagation = var.enable_default_route_table_propagation ? enable : disable
+  auto_accept_shared_attachments  = var.auto_accept_attachments ? enable : disable
+  dns_support                     = var.enable_dns_support
+  amazon_side_asn                 = var.amazon_side_asn
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.tgw_tags)}"
+  tags = merge(map("Name", format("%s", var.name)), var.tags, var.tgw_tags)
 }
 
 resource "aws_ec2_transit_gateway_route_table" "tgw" {
-  count = "${var.create_tgw ? 1 : 0}"
+  count = var.create_tgw ? 1 : 0
 
-  transit_gateway_id = "${aws_ec2_transit_gateway.tgw.id}"
-  tags               = "${merge(map("Name", format("%s", var.name)), var.tags, var.tgw_route_table_tags)}"
+  transit_gateway_id = aws_ec2_transit_gateway.tgw.id
+  tags               = merge(map("Name", format("%s", var.name)), var.tags, var.tgw_route_table_tags)
 }
 
 resource "aws_ram_resource_share" "ram_share" {
-  count = "${var.create_tgw && var.share_tgw ? 1 : 0}"
+  count = var.create_tgw && var.share_tgw ? 1 : 0
 
-  name                      = "${var.name}"
-  allow_external_principals = "${var.allow_external_principals}"
+  name                      = var.name
+  allow_external_principals = var.allow_external_principals
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.tags, var.ram_share_principals)}"
+  tags = merge(map("Name", format("%s", var.name)), var.tags, var.ram_share_principals)
 }
 
 resource "aws_ram_resource_association" "ram_resource_association" {
-  count = "${var.create_tgw && var.share_tgw ? 1 : 0}"
+  count = var.create_tgw && var.share_tgw ? 1 : 0
 
-  resource_arn       = "${aws_ec2_transit_gateway.tgw.arn}"
-  resource_share_arn = "${aws_ram_resource_share.ram_share.id}"
+  resource_arn       = aws_ec2_transit_gateway.tgw.arn
+  resource_share_arn = aws_ram_resource_share.ram_share.id
 }
 
 resource "aws_ram_principal_association" "ram_principal_association" {
-  count = "${var.create_tgw && var.share_tgw && length(var.ram_share_principals) > 0 ? length(var.ram_share_principals) : 0}"
+  count = var.create_tgw && var.share_tgw && length(var.ram_share_principals) > 0 ? length(var.ram_share_principals) : 0
 
-  principal          = "${var.ram_share_principals[count.index]}"
-  resource_share_arn = "${aws_ram_resource_share.ram_share.arn}"
+  principal          = var.ram_share_principals[count.index]
+  resource_share_arn = aws_ram_resource_share.ram_share.arn
 }

--- a/output.tf
+++ b/output.tf
@@ -1,34 +1,34 @@
 output "tgw_id" {
   description = "The ID of the TGW"
-  value       = "${element(concat(aws_ec2_transit_gateway.tgw.id, list("")), 0)}"
+  value       = element(concat(aws_ec2_transit_gateway.tgw.id, list("")), 0)
 }
 
 output "tgw_arn" {
   description = "The ARN of the TGW"
-  value       = "${element(concat(aws_ec2_transit_gateway.tgw.arn, list("")), 0)}"
+  value       = element(concat(aws_ec2_transit_gateway.tgw.arn, list("")), 0)
 }
 
 output "tgw_route_table_id" {
   description = "The ID of the TGW route table"
-  value       = "${element(concat(aws_ec2_transit_gateway_route_table.tgw.id, list("")), 0)}"
+  value       = element(concat(aws_ec2_transit_gateway_route_table.tgw.id, list("")), 0)
 }
 
 output "ram_share_id" {
   description = "The ID of the RAM Share"
-  value       = "${element(concat(aws_ram_resource_share.ram_share.id, list("")), 0)}"
+  value       = element(concat(aws_ram_resource_share.ram_share.id, list("")), 0)
 }
 
 output "ram_share_arn" {
   description = "The ARN of the RAM Share"
-  value       = "${element(concat(aws_ram_resource_share.ram_share.arn, list("")), 0)}"
+  value       = element(concat(aws_ram_resource_share.ram_share.arn, list("")), 0)
 }
 
 output "ram_resource_association_id" {
   description = "The ID of the RAM Resource Association"
-  value       = "${element(concat(aws_ram_resource_association.ram_resource_association.id, list("")), 0)}"
+  value       = element(concat(aws_ram_resource_association.ram_resource_association.id, list("")), 0)
 }
 
 output "ram_principal_association_ids" {
   description = "Map of Principal of to the RAM Principal Association ID"
-  value       = "${zipmap(var.ram_share_principals,list(aws_ram_principal_association.ram_principal_association.*.id))}"
+  value       = zipmap(var.ram_share_principals, list(aws_ram_principal_association.ram_principal_association.*.id))
 }


### PR DESCRIPTION
cleanup deprecated interpolation-only expressions.

validates clean on my side, but probably needs a review.

Signed-off-by: AJ Dexter <aj.dexter@gmail.com>